### PR TITLE
Fix removeNaNFromPointCloud

### DIFF
--- a/src/laserProcessingClass.cpp
+++ b/src/laserProcessingClass.cpp
@@ -12,7 +12,7 @@ void LaserProcessingClass::init(lidar::Lidar lidar_param_in){
 void LaserProcessingClass::featureExtraction(const pcl::PointCloud<pcl::PointXYZI>::Ptr& pc_in, pcl::PointCloud<pcl::PointXYZI>::Ptr& pc_out_edge, pcl::PointCloud<pcl::PointXYZI>::Ptr& pc_out_surf){
 
     std::vector<int> indices;
-    pcl::removeNaNFromPointCloud(*pc_in, indices);
+    pcl::removeNaNFromPointCloud(*pc_in, *pc_in, indices);
 
 
     int N_SCANS = lidar_param.num_lines;


### PR DESCRIPTION
The current removeNaNFromPointCloud does not modify the input point cloud. Adding a second *pc_in so that input can be modified. See https://pointclouds.org/documentation/group__filters.html#ga0839c52ff34eb1f6ffc58cf5cc853bd8